### PR TITLE
fix: correct 22:00 sleep status

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,7 +371,7 @@
             } else if (cetDay >= 1 && cetDay <= 5 && cetHour >= 6 && cetHour < 9) {
                 status = "Family time";
                 statusColor = "#FF9500"; // Orange
-            } else if (cetDay >= 1 && cetDay <= 5 && (cetHour >= 18 && cetHour <= 22)) {
+            } else if (cetDay >= 1 && cetDay <= 5 && cetHour >= 18 && cetHour < 22) {
                 status = "Family time";
                 statusColor = "#007AFF"; // Blue
             } else if (cetHour >= 22 || cetHour < 6) {


### PR DESCRIPTION
## Summary
- ensure hour 22 falls into the sleeping block by making the weekday evening family-time condition use `< 22` instead of `<= 22`

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b3b628cb4832c9da729f9f1984860