### PR TITLE
Fix profile fallback icon flicker

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -305,10 +305,9 @@ body::before {
 .profile-fallback {
     position: absolute;
     z-index: 1;
-}
-
-/* Hide fallback when image loads successfully */
-.profile-photo:has(.profile-image) .profile-fallback {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     display: none;
 }
 


### PR DESCRIPTION
## Summary
- hide profile fallback icon by default and center it for when the image fails

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689b2f40333c832c8d41e433d933c6a3