### PR TITLE
Enhance SEO metadata and content

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="description" content="Discover Jop ter Horst, Technical Account Manager at Mendix in the Netherlands. Explore his portfolio, AI-driven projects, speaking engagements, and expertise in guiding ISVs.">
+    <meta name="keywords" content="Jop ter Horst, Technical Account Manager, Mendix, GenAI, Netherlands, ISV strategy, low-code expert">
+    <meta name="author" content="Jop ter Horst">
+    <link rel="canonical" href="https://jopterhorst.nl/">
     
     <!-- iOS Safari theme colors -->
     <meta name="theme-color" content="#c3cfe2">
@@ -12,6 +16,17 @@
     <meta name="apple-mobile-web-app-title" content="Jop ter Horst">
     
     <title>Jop ter Horst - Portfolio</title>
+
+    <meta property="og:site_name" content="Jop ter Horst">
+    <meta property="og:title" content="Jop ter Horst - Mendix Technical Account Manager">
+    <meta property="og:description" content="Learn about Jop ter Horst's Mendix expertise, GenAI strategy, and portfolio of low-code innovations based in the Netherlands.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://jopterhorst.nl/">
+    <meta property="og:image" content="https://jopterhorst.nl/assets/profile-photo.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Jop ter Horst - Mendix Technical Account Manager">
+    <meta name="twitter:description" content="Explore the work of Jop ter Horst, a Mendix specialist focused on GenAI solutions for ISVs.">
+    <meta name="twitter:image" content="https://jopterhorst.nl/assets/profile-photo.jpg">
     
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
@@ -27,6 +42,38 @@
     <!-- Feather Icons for clean, Apple-like icons -->
     <script src="https://unpkg.com/feather-icons"></script>
     <link rel="stylesheet" href="styles.css">
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "Person",
+            "name": "Jop ter Horst",
+            "jobTitle": "Technical Account Manager",
+            "worksFor": {
+                "@type": "Organization",
+                "name": "Mendix"
+            },
+            "url": "https://jopterhorst.nl/",
+            "image": "https://jopterhorst.nl/assets/profile-photo.jpg",
+            "email": "mailto:jop@jopterhorst.nl",
+            "nationality": "Dutch",
+            "address": {
+                "@type": "PostalAddress",
+                "addressCountry": "NL"
+            },
+            "sameAs": [
+                "https://www.linkedin.com/in/jopterhorst/",
+                "https://github.com/jopterhorst"
+            ],
+            "knowsAbout": [
+                "Mendix",
+                "Independent Software Vendor strategy",
+                "Generative AI",
+                "Technical consulting",
+                "Low-code development"
+            ]
+        }
+    </script>
 </head>
 <body>
     <!-- Animated Background -->
@@ -243,6 +290,40 @@
                     </div>
                 </div>
             </div>
+
+            <section class="pillar glass-card fade-in bio-section" aria-labelledby="about-heading">
+                <h2 class="pillar-title" id="about-heading">About Jop ter Horst</h2>
+                <p>Jop ter Horst is a Dutch Technical Account Manager at Mendix who empowers Independent Software Vendors to design resilient, scalable products on the Mendix low-code platform. Drawing on a decade of customer-facing experience, he helps organisations capture value faster by combining platform governance, AI-driven enhancements, and a pragmatic approach to solution architecture.</p>
+                <p>Beyond guiding ISVs, Jop ter Horst experiments with emerging technologies and shares insights on embedding generative AI responsibly into enterprise workflows. He regularly coaches product teams on discovery, enablement, and lifecycle management so they can keep shipping high-quality applications without losing momentum.</p>
+            </section>
+
+            <section class="pillar glass-card fade-in highlights-section" aria-labelledby="highlights-heading">
+                <h2 class="pillar-title" id="highlights-heading">Professional Highlights</h2>
+                <ul class="highlights-list">
+                    <li>Trusted advisor to Mendix marketplace partners, leading technical reviews that ensure security, performance, and AI readiness for customer-facing solutions.</li>
+                    <li>Speaker and workshop host on how Independent Software Vendors can accelerate go-to-market motions with GenAI copilots, responsible AI policies, and human-in-the-loop design.</li>
+                    <li>Creator of Mendix audio tooling such as the Vibe Audio Recorder and Transcription module, demonstrating how Jop ter Horst blends TypeScript, Java, and low-code components.</li>
+                    <li>Collaborates with cross-functional Mendix teams to translate complex business requirements into actionable product roadmaps and measurable customer impact.</li>
+                </ul>
+            </section>
+
+            <section class="pillar glass-card fade-in faq-section" aria-labelledby="faq-heading">
+                <h2 class="pillar-title" id="faq-heading">Frequently Asked Questions about Jop ter Horst</h2>
+                <div class="faq-list">
+                    <details>
+                        <summary>Who is Jop ter Horst?</summary>
+                        <p>Jop ter Horst is a Netherlands-based Technical Account Manager at Mendix, partnering with Independent Software Vendors to modernise products with low-code and GenAI capabilities.</p>
+                    </details>
+                    <details>
+                        <summary>What does Jop ter Horst specialise in?</summary>
+                        <p>He specialises in Mendix platform strategy, solution architecture, and embedding responsible generative AI workflows that help SaaS providers scale securely.</p>
+                    </details>
+                    <details>
+                        <summary>How can I collaborate with Jop ter Horst?</summary>
+                        <p>You can reach out via <a href="mailto:jop@jopterhorst.nl">email</a> or connect on <a href="https://www.linkedin.com/in/jopterhorst/" target="_blank" rel="noopener">LinkedIn</a> to discuss speaking engagements, advisory roles, or Mendix projects.</p>
+                    </details>
+                </div>
+            </section>
         </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -516,6 +516,64 @@ body::before {
     border-radius: 2px;
 }
 
+.bio-section p {
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: var(--text-secondary);
+    margin-bottom: 1.25rem;
+    text-align: left;
+}
+
+.highlights-list {
+    list-style: disc;
+    margin-left: 1.5rem;
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+
+.highlights-list li {
+    margin-bottom: 0.85rem;
+}
+
+.faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    text-align: left;
+}
+
+.faq-list details {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 1.25rem 1.5rem;
+    box-shadow:
+        0 4px 16px var(--shadow-color),
+        inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    transition: all 0.3s ease;
+}
+
+.faq-list details[open] {
+    background: var(--bg-secondary);
+}
+
+.faq-list summary {
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--text-primary);
+    list-style: none;
+}
+
+.faq-list summary::-webkit-details-marker {
+    display: none;
+}
+
+.faq-list p {
+    margin-top: 0.75rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
 /* Optimized Experience Items */
 .experience-item, .skill-item, .project-item {
     padding: 1.5rem;


### PR DESCRIPTION
## Summary
- add SEO-focused metadata, social previews, and person schema for Jop ter Horst
- expand the portfolio page with biography, highlights, and FAQ content that reinforce expertise
- style new narrative sections and FAQ interactions to match the existing visual language

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4bfd5420832ca7f951f7b2c68e7b)