### PR TITLE
Group experience entries by employer

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
                             <div class="experience-group-subtitle">Sep 2024 - Present</div>
                         </div>
                         <div class="experience-group-roles">
-                            <div class="experience-item">
+                            <div class="experience-item experience-role">
                                 <div class="item-title">Technical Account Manager</div>
                                 <div class="item-subtitle">Sep 2024 - Present</div>
                                 <div class="item-description">Partnering with Independent Software Vendors (ISVs) to build scalable, adaptable software products on Mendix. I advise external partners and lead internal Siemens teams to ship commercial solutions faster through architecture guidance, best practices, and AI enablement. Key contributions include integrating LLM-powered tooling for revenue teams, standardizing ISV playbooks, and enabling double-digit ACV growth through faster time-to-market.</div>
@@ -100,25 +100,25 @@
                             <div class="experience-group-subtitle">Mar 2020 - Aug 2024</div>
                         </div>
                         <div class="experience-group-roles">
-                            <div class="experience-item">
+                            <div class="experience-item experience-role">
                                 <div class="item-title">Solution Consultant</div>
                                 <div class="item-subtitle">Nov 2022 - Aug 2024</div>
                                 <div class="item-description">Owned Mendix presales solution design and architecture across the Netherlands, DACH, and the Nordics. Delivered platform introductions, demo apps, RFP designs, effort estimates, and license optimization. Led presales for Mendix DLM for Fashion & Retail, integrating Teamcenter into a single source of truth for product development data.</div>
                             </div>
 
-                            <div class="experience-item">
+                            <div class="experience-item experience-role">
                                 <div class="item-title">Expert Mendix Consultant</div>
                                 <div class="item-subtitle">Oct 2022 - Aug 2023</div>
                                 <div class="item-description">Led multiple application development teams with a focus on quality, best practices, reusability, and compliance.</div>
                             </div>
 
-                            <div class="experience-item">
+                            <div class="experience-item experience-role">
                                 <div class="item-title">Advanced Mendix Consultant</div>
                                 <div class="item-subtitle">Oct 2020 - Sep 2022</div>
                                 <div class="item-description">Delivered Mendix implementations for clients in the Netherlands, emphasizing scalable application architecture and delivery excellence.</div>
                             </div>
 
-                            <div class="experience-item">
+                            <div class="experience-item experience-role">
                                 <div class="item-title">Mendix Consultant</div>
                                 <div class="item-subtitle">Mar 2020 - Sep 2020</div>
                                 <div class="item-description">Built and supported Mendix applications, partnering with stakeholders to deliver early wins and stable releases.</div>
@@ -132,7 +132,7 @@
                             <div class="experience-group-subtitle">2018 - 2020</div>
                         </div>
                         <div class="experience-group-roles">
-                            <div class="experience-item">
+                            <div class="experience-item experience-role">
                                 <div class="item-title">Presales Consultant</div>
                                 <div class="item-subtitle">2018 - 2020</div>
                                 <div class="item-description">Supported sales teams with technical expertise, delivered product demonstrations, and helped prospects understand platform capabilities. Created technical proposals and proof-of-concepts for prospective clients.</div>

--- a/index.html
+++ b/index.html
@@ -80,40 +80,64 @@
                 <div class="pillar glass-card fade-in">
                     <h2 class="pillar-title">Experience</h2>
                     
-                    <div class="experience-item">
-                        <div class="item-title">Technical Account Manager</div>
-                        <div class="item-subtitle">Siemens Digital Industries Software (Mendix) • Sep 2024 - Present</div>
-                        <div class="item-description">Partnering with Independent Software Vendors (ISVs) to build scalable, adaptable software products on Mendix. I advise external partners and lead internal Siemens teams to ship commercial solutions faster through architecture guidance, best practices, and AI enablement. Key contributions include integrating LLM-powered tooling for revenue teams, standardizing ISV playbooks, and enabling double-digit ACV growth through faster time-to-market.</div>
+                    <div class="experience-group">
+                        <div class="experience-group-header">
+                            <div class="experience-group-title">Siemens Digital Industries Software (Mendix)</div>
+                            <div class="experience-group-subtitle">Sep 2024 - Present</div>
+                        </div>
+                        <div class="experience-group-roles">
+                            <div class="experience-item">
+                                <div class="item-title">Technical Account Manager</div>
+                                <div class="item-subtitle">Sep 2024 - Present</div>
+                                <div class="item-description">Partnering with Independent Software Vendors (ISVs) to build scalable, adaptable software products on Mendix. I advise external partners and lead internal Siemens teams to ship commercial solutions faster through architecture guidance, best practices, and AI enablement. Key contributions include integrating LLM-powered tooling for revenue teams, standardizing ISV playbooks, and enabling double-digit ACV growth through faster time-to-market.</div>
+                            </div>
+                        </div>
                     </div>
 
-                    <div class="experience-item">
-                        <div class="item-title">Solution Consultant</div>
-                        <div class="item-subtitle">CLEVR • Nov 2022 - Aug 2024</div>
-                        <div class="item-description">Owned Mendix presales solution design and architecture across the Netherlands, DACH, and the Nordics. Delivered platform introductions, demo apps, RFP designs, effort estimates, and license optimization. Led presales for Mendix DLM for Fashion & Retail, integrating Teamcenter into a single source of truth for product development data.</div>
+                    <div class="experience-group">
+                        <div class="experience-group-header">
+                            <div class="experience-group-title">CLEVR</div>
+                            <div class="experience-group-subtitle">Mar 2020 - Aug 2024</div>
+                        </div>
+                        <div class="experience-group-roles">
+                            <div class="experience-item">
+                                <div class="item-title">Solution Consultant</div>
+                                <div class="item-subtitle">Nov 2022 - Aug 2024</div>
+                                <div class="item-description">Owned Mendix presales solution design and architecture across the Netherlands, DACH, and the Nordics. Delivered platform introductions, demo apps, RFP designs, effort estimates, and license optimization. Led presales for Mendix DLM for Fashion & Retail, integrating Teamcenter into a single source of truth for product development data.</div>
+                            </div>
+
+                            <div class="experience-item">
+                                <div class="item-title">Expert Mendix Consultant</div>
+                                <div class="item-subtitle">Oct 2022 - Aug 2023</div>
+                                <div class="item-description">Led multiple application development teams with a focus on quality, best practices, reusability, and compliance.</div>
+                            </div>
+
+                            <div class="experience-item">
+                                <div class="item-title">Advanced Mendix Consultant</div>
+                                <div class="item-subtitle">Oct 2020 - Sep 2022</div>
+                                <div class="item-description">Delivered Mendix implementations for clients in the Netherlands, emphasizing scalable application architecture and delivery excellence.</div>
+                            </div>
+
+                            <div class="experience-item">
+                                <div class="item-title">Mendix Consultant</div>
+                                <div class="item-subtitle">Mar 2020 - Sep 2020</div>
+                                <div class="item-description">Built and supported Mendix applications, partnering with stakeholders to deliver early wins and stable releases.</div>
+                            </div>
+                        </div>
                     </div>
 
-                    <div class="experience-item">
-                        <div class="item-title">Expert Mendix Consultant</div>
-                        <div class="item-subtitle">CLEVR • Oct 2022 - Aug 2023</div>
-                        <div class="item-description">Led multiple application development teams with a focus on quality, best practices, reusability, and compliance.</div>
-                    </div>
-
-                    <div class="experience-item">
-                        <div class="item-title">Advanced Mendix Consultant</div>
-                        <div class="item-subtitle">CLEVR • Oct 2020 - Sep 2022</div>
-                        <div class="item-description">Delivered Mendix implementations for clients in the Netherlands, emphasizing scalable application architecture and delivery excellence.</div>
-                    </div>
-
-                    <div class="experience-item">
-                        <div class="item-title">Mendix Consultant</div>
-                        <div class="item-subtitle">CLEVR • Mar 2020 - Sep 2020</div>
-                        <div class="item-description">Built and supported Mendix applications, partnering with stakeholders to deliver early wins and stable releases.</div>
-                    </div>
-
-                    <div class="experience-item">
-                        <div class="item-title">Presales Consultant</div>
-                        <div class="item-subtitle">Thinkwise • 2018 - 2020</div>
-                        <div class="item-description">Supported sales teams with technical expertise, delivered product demonstrations, and helped prospects understand platform capabilities. Created technical proposals and proof-of-concepts for prospective clients.</div>
+                    <div class="experience-group">
+                        <div class="experience-group-header">
+                            <div class="experience-group-title">Thinkwise</div>
+                            <div class="experience-group-subtitle">2018 - 2020</div>
+                        </div>
+                        <div class="experience-group-roles">
+                            <div class="experience-item">
+                                <div class="item-title">Presales Consultant</div>
+                                <div class="item-subtitle">2018 - 2020</div>
+                                <div class="item-description">Supported sales teams with technical expertise, delivered product demonstrations, and helped prospects understand platform capabilities. Created technical proposals and proof-of-concepts for prospective clients.</div>
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -544,15 +544,28 @@ body::before {
 
 .experience-group {
     margin-bottom: 2rem;
-    padding: 1.75rem;
-    border-radius: 20px;
-    background: color-mix(in srgb, var(--bg-secondary), transparent 10%);
-    border: 1px solid var(--border-color);
-    box-shadow: 0 6px 20px var(--shadow-color);
+    padding: 2rem;
+    border-radius: 24px;
+    background: color-mix(in srgb, var(--bg-secondary), transparent 12%);
+    border: 0.5px solid color-mix(in srgb, var(--border-color), transparent 15%);
+    box-shadow: 
+        0 10px 30px color-mix(in srgb, var(--shadow-color), transparent 10%),
+        inset 0 1px 0 color-mix(in srgb, white, transparent 85%);
+    position: relative;
+    overflow: hidden;
 }
 
 .experience-group:last-of-type {
     margin-bottom: 0;
+}
+
+.experience-group::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top left, rgba(0, 122, 255, 0.08), transparent 55%);
+    opacity: 0.8;
+    pointer-events: none;
 }
 
 .experience-group-header {
@@ -561,12 +574,15 @@ body::before {
     justify-content: space-between;
     gap: 1rem;
     margin-bottom: 1.5rem;
+    position: relative;
+    z-index: 1;
 }
 
 .experience-group-title {
     font-size: 1.15rem;
     font-weight: 700;
     color: var(--text-primary);
+    letter-spacing: -0.01em;
 }
 
 .experience-group-subtitle {
@@ -579,15 +595,54 @@ body::before {
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    position: relative;
+    padding-left: 1.5rem;
+    z-index: 1;
 }
 
-.experience-group-roles .experience-item {
+.experience-group-roles::before {
+    content: '';
+    position: absolute;
+    top: 0.25rem;
+    bottom: 0.25rem;
+    left: 0.45rem;
+    width: 2px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--text-tertiary), transparent 60%);
+}
+
+.experience-role {
     margin-bottom: 0;
-    border-left: 3px solid color-mix(in srgb, var(--text-tertiary), transparent 55%);
+    padding: 0.5rem 0 0.75rem 0;
+    background: none;
+    border: none;
+    box-shadow: none;
+    position: relative;
+    transition: transform 0.3s ease;
 }
 
-.experience-group-roles .experience-item:hover {
-    border-left-color: color-mix(in srgb, var(--text-secondary), transparent 45%);
+.experience-role::before {
+    content: '';
+    position: absolute;
+    left: -0.15rem;
+    top: 0.35rem;
+    width: 0.9rem;
+    height: 0.9rem;
+    border-radius: 50%;
+    background: var(--bg-secondary);
+    border: 2px solid color-mix(in srgb, var(--text-secondary), transparent 45%);
+    box-shadow: 0 6px 14px color-mix(in srgb, var(--shadow-color), transparent 20%);
+}
+
+.experience-role:hover {
+    transform: translateX(4px);
+    background: none;
+    box-shadow: none;
+    border-color: transparent;
+}
+
+.experience-role:hover::before {
+    border-color: color-mix(in srgb, var(--text-primary), transparent 35%);
 }
 
 .item-title {
@@ -875,7 +930,7 @@ body::before {
     }
 
     .experience-group {
-        padding: 1.5rem 1.25rem;
+        padding: 1.5rem;
     }
 
     .experience-group-header {
@@ -885,6 +940,10 @@ body::before {
 
     .experience-group-subtitle {
         white-space: normal;
+    }
+
+    .experience-group-roles {
+        padding-left: 1.25rem;
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -583,11 +583,11 @@ body::before {
 
 .experience-group-roles .experience-item {
     margin-bottom: 0;
-    border-left: 4px solid rgba(0, 122, 255, 0.2);
+    border-left: 3px solid color-mix(in srgb, var(--text-tertiary), transparent 55%);
 }
 
 .experience-group-roles .experience-item:hover {
-    border-left-color: rgba(0, 122, 255, 0.4);
+    border-left-color: color-mix(in srgb, var(--text-secondary), transparent 45%);
 }
 
 .item-title {

--- a/styles.css
+++ b/styles.css
@@ -596,42 +596,17 @@ body::before {
     flex-direction: column;
     gap: 1rem;
     position: relative;
-    padding-left: 1.5rem;
     z-index: 1;
-}
-
-.experience-group-roles::before {
-    content: '';
-    position: absolute;
-    top: 0.25rem;
-    bottom: 0.25rem;
-    left: 0.45rem;
-    width: 2px;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--text-tertiary), transparent 60%);
 }
 
 .experience-role {
     margin-bottom: 0;
-    padding: 0.5rem 0 0.75rem 1.25rem;
+    padding: 0.75rem 0;
     background: none;
     border: none;
     box-shadow: none;
     position: relative;
     transition: transform 0.3s ease;
-}
-
-.experience-role::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0.35rem;
-    width: 0.9rem;
-    height: 0.9rem;
-    border-radius: 50%;
-    background: var(--bg-secondary);
-    border: 2px solid color-mix(in srgb, var(--text-secondary), transparent 45%);
-    box-shadow: 0 6px 14px color-mix(in srgb, var(--shadow-color), transparent 20%);
 }
 
 .experience-role:hover {
@@ -641,8 +616,9 @@ body::before {
     border-color: transparent;
 }
 
-.experience-role:hover::before {
-    border-color: color-mix(in srgb, var(--text-primary), transparent 35%);
+.experience-role + .experience-role {
+    border-top: 1px solid color-mix(in srgb, var(--border-color), transparent 30%);
+    padding-top: 1.25rem;
 }
 
 .item-title {
@@ -940,10 +916,6 @@ body::before {
 
     .experience-group-subtitle {
         white-space: normal;
-    }
-
-    .experience-group-roles {
-        padding-left: 1.25rem;
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -613,7 +613,7 @@ body::before {
 
 .experience-role {
     margin-bottom: 0;
-    padding: 0.5rem 0 0.75rem 0;
+    padding: 0.5rem 0 0.75rem 1.25rem;
     background: none;
     border: none;
     box-shadow: none;
@@ -624,7 +624,7 @@ body::before {
 .experience-role::before {
     content: '';
     position: absolute;
-    left: -0.15rem;
+    left: 0;
     top: 0.35rem;
     width: 0.9rem;
     height: 0.9rem;

--- a/styles.css
+++ b/styles.css
@@ -542,6 +542,54 @@ body::before {
     border-color: var(--border-color);
 }
 
+.experience-group {
+    margin-bottom: 2rem;
+    padding: 1.75rem;
+    border-radius: 20px;
+    background: color-mix(in srgb, var(--bg-secondary), transparent 10%);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 6px 20px var(--shadow-color);
+}
+
+.experience-group:last-of-type {
+    margin-bottom: 0;
+}
+
+.experience-group-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.experience-group-title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.experience-group-subtitle {
+    font-size: 0.95rem;
+    color: var(--text-tertiary);
+    white-space: nowrap;
+}
+
+.experience-group-roles {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.experience-group-roles .experience-item {
+    margin-bottom: 0;
+    border-left: 4px solid rgba(0, 122, 255, 0.2);
+}
+
+.experience-group-roles .experience-item:hover {
+    border-left-color: rgba(0, 122, 255, 0.4);
+}
+
 .item-title {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     font-size: 1.2rem;
@@ -824,6 +872,19 @@ body::before {
     .pillar {
         padding: 2rem 1rem;
         min-height: auto;
+    }
+
+    .experience-group {
+        padding: 1.5rem 1.25rem;
+    }
+
+    .experience-group-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .experience-group-subtitle {
+        white-space: normal;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Multiple roles from the same employer should be visually grouped so each role reads as a distinct position while showing they belong to the same company and remain clear on mobile.

### Description
- Replace flat `experience-item` entries in `index.html` with `experience-group` blocks containing a shared employer header and nested `experience-group-roles` for each role.
- Add styling in `styles.css` for `.experience-group`, `.experience-group-header`, `.experience-group-title`, `.experience-group-subtitle`, and `.experience-group-roles` to create card-like employer groups and a left accent for individual roles.
- Add responsive tweaks so employer headers stack and subtitles wrap on small screens to ensure a good mobile layout.
- Minor visual polish (background, shadow, spacing) for the grouped blocks to match existing glass-card styling.

### Testing
- Launched a local static server with `python -m http.server 8000` and ran a Playwright script to capture desktop and mobile screenshots, producing `artifacts/experience-grouping-desktop.png` and `artifacts/experience-grouping-mobile.png`, which completed successfully.
- No unit tests were applicable for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b8cc2bf78832c92dfca998320b9f5)